### PR TITLE
crawlers run on multiple processes

### DIFF
--- a/jc_lib/crawlers.py
+++ b/jc_lib/crawlers.py
@@ -17,6 +17,7 @@ from webdriver_manager.chrome import ChromeDriverManager
 from webdriver_manager.core.os_manager import ChromeType
 
 from jc_lib.reporting import ReportItem
+from jc_lib.reporting import ParallelReportItem
 
 
 class Crawler():

--- a/jc_lib/crawlers.py
+++ b/jc_lib/crawlers.py
@@ -17,7 +17,6 @@ from webdriver_manager.chrome import ChromeDriverManager
 from webdriver_manager.core.os_manager import ChromeType
 
 from jc_lib.reporting import ReportItem
-from jc_lib.reporting import ParallelReportItem
 
 
 class Crawler():

--- a/main.py3
+++ b/main.py3
@@ -16,6 +16,35 @@ from jc_lib.companies.Apple import AppleCrawler
 from jc_lib.companies.Amazon import AmazonCrawler
 from jc_lib.reporting import ReportItem
 
+from multiprocessing import Queue
+from multiprocessing import Process
+from multiprocessing import Pool
+from multiprocessing import set_start_method
+
+# Primary web crawler.
+# Takes a url, pages through any subsequent pages, and outputs any job items 
+# extracted.
+#
+# Signals completion to Consumers by sending None.
+def crawl_worker(input_queue, now_datestring, post_process_queue, output_queue):
+  while input_queue.qsize() > 0:
+    crawlerClass = input_queue.get()
+    crawler = crawlerClass(now_datestring)
+    for item in crawler.crawl():
+      output_queue.put(item)
+  output_queue.put(None)
+
+# Side process for crawlers that need their job items post-processed.
+# Takes items and runs their post-processing
+#
+# Signals completion to Consumers by sending None.
+def post_process_worker(post_process_queue, output_queue):
+  while True:
+    item = post_process_queue.get()
+    output_queue.put(item)
+    if item == None: break
+  output_queue.put(None)
+
 
 if __name__ == "__main__":
   parser = argparse.ArgumentParser()
@@ -46,30 +75,52 @@ if __name__ == "__main__":
       job = ReportItem.from_row(header, row)
       all_jobs[job.url] = job
 
-  # Crawl new jobs
   jobs = []
-  
-  crawler = GoogleCrawler(now_datestring)
-  new_jobs = crawler.crawl()
-  if len(new_jobs) < 1: alerts.report_company_missing_jobs(crawler.company_name)
-  jobs = jobs + new_jobs
-  
-  crawler = MicrosoftCrawler(now_datestring)
-  new_jobs = crawler.crawl()
-  if len(new_jobs) < 1: alerts.report_company_missing_jobs(crawler.company_name)
-  jobs = jobs + new_jobs
-  del crawler
-  
-  crawler = AppleCrawler(now_datestring)
-  new_jobs = crawler.crawl()
-  if len(new_jobs) < 1: alerts.report_company_missing_jobs(crawler.company_name)
-  jobs = jobs + new_jobs
-  
-  crawler = AmazonCrawler(now_datestring)
-  new_jobs = crawler.crawl()
-  if len(new_jobs) < 1: alerts.report_company_missing_jobs(crawler.company_name)
-  jobs = jobs + new_jobs
-  del crawler
+  # Setup multithreading
+  set_start_method('spawn')
+  ## Initial pages queue
+  unused_crawlers = Queue()
+  ## interstitial processing queue
+  list_items_queue = Queue()
+  ## Ready-to-print queue
+  output_queue = Queue()
+
+  ## Enqueue initial crawlers
+  unused_crawlers.put(GoogleCrawler)
+  unused_crawlers.put(MicrosoftCrawler)
+  unused_crawlers.put(AppleCrawler)
+  unused_crawlers.put(AmazonCrawler)
+ 
+  ## Setup workers 
+  crawler1 = Process(target=crawl_worker, args=(unused_crawlers,now_datestring,list_items_queue, output_queue))
+  crawler2 = Process(target=crawl_worker, args=(unused_crawlers,now_datestring,list_items_queue, output_queue))
+  post_processor = Process(target=post_process_worker, args=(list_items_queue, output_queue))
+
+  crawl_processes = []
+  crawl_processes.append(crawler1)
+  crawl_processes.append(crawler2)
+
+  item_processes = []
+  item_processes.append(post_processor)
+
+  ## Use blocking calls to extract items from the queue until every process has
+  ## signalled its completion.
+  processes = crawl_processes + item_processes
+  closed_workers = 0
+  for p in processes:
+    p.start()
+
+  while closed_workers < len(processes): 
+    item = output_queue.get()
+    if item:
+      jobs.append(item)
+    else:
+      closed_workers = closed_workers + 1
+    ### We have to shut down post-processor after we're sure crawling is done
+    if closed_workers >= len(crawl_processes) and list_items_queue.qsize() < 1:
+      list_items_queue.put(None)
+  for p in processes:
+    p.join()
   
   # Output jobs reports
   print("Generating report...")

--- a/main.py3
+++ b/main.py3
@@ -18,7 +18,6 @@ from jc_lib.reporting import ReportItem
 
 from multiprocessing import Queue
 from multiprocessing import Process
-from multiprocessing import Pool
 from multiprocessing import set_start_method
 
 # Primary web crawler.


### PR DESCRIPTION
Using multiproc to execute crawlers in parallel to optimize blocking I/O time.

Running crawlers in parallel takes advantage of the long blocking I/O for accessing so many web pages (especially the overhead of Selenium)

Need to favor multiprocesses over threads because
1. CPython doesn't support running multiple threads, the script is inherently less portable
2. B/c we need things like the Selenium driver, we'll always have a lot of context that is easier to manage if we carve out seperate spaces for them

Results on a local test seem good, about 40% reduction in run time. Both executions produced the same number of new rows,

Threads
```
real    6m47.742s
user    0m32.624s
sys    0m6.777s
```

No threads
```
real    11m32.145s
user    0m27.371s
sys    0m6.750s
```